### PR TITLE
Create reusable Tag component with size variants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import Banner from './components/Banner'
 import Header from './components/Header'
 
 import { GlobalCss } from './styles/styles'
@@ -9,6 +10,7 @@ function App() {
       <div>
         <Header />
       </div>
+      <Banner />
     </>
   )
 }

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { Colors } from '../../styles/styles'
+import { colors } from '../../styles/styles'
 
 export const HeaderBar = styled.header`
   width: 100%;
@@ -8,7 +8,7 @@ export const HeaderBar = styled.header`
   align-items: center;
 
   a {
-    color: ${Colors.pink};
+    color: ${colors.pink};
     text-decoration: none;
   }
 `

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,0 +1,12 @@
+import { TagContainer } from './styles'
+
+export type Props = {
+  size?: 'small' | 'big'
+  children: string
+}
+
+const Tag = ({ children, size = 'small' }: Props) => (
+  <TagContainer size={size}>{children}</TagContainer>
+)
+
+export default Tag

--- a/src/components/Tag/styles.ts
+++ b/src/components/Tag/styles.ts
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+import type { Props } from '.'
+import { colors } from '../../styles/styles'
+
+export const TagContainer = styled.div<Props>`
+  background-color: ${colors.pink};
+  color: ${colors.peach};
+  font-size: ${(props) => (props.size === 'big' ? '32px' : '12px')};
+  font-weight: 700;
+  padding: 6px 4px;
+`

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components'
 
-export const Colors = {
+export const colors = {
   pink: '#E66767',
   peach: '#FFEBD9',
   white: '#FFFFFF',
@@ -16,8 +16,8 @@ export const GlobalCss = createGlobalStyle`
   list-style: none;
 }
 body {
-  background-color: ${Colors.cream};
-  color: ${Colors.pink};
+  background-color: ${colors.cream};
+  color: ${colors.pink};
 }
 
 .container {


### PR DESCRIPTION
Closes #8 

## Changes Made:
- Created Tag component with configurable size ("small" | "big")
- Used Styled Components and global color palette
- Added TypeScript props for type safety
- Component is reusable for categories, labels, etc.

## Features:
- Accepts children as label text
- Supports "small" and "big" size variants
- Follows design system standards

## Testing:
- [x] Tag renders correctly with both size options
- [x] Styling and colors are consistent

## Notes:
This component will be used in Banner and other future components.